### PR TITLE
Export: Create new glyphs entries when export range is outside of contained glyphs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -585,6 +585,7 @@ $(document).ready(function () {
     let isFirstCharacter = true
     const firstglyph = parseInt($('#firstglyph').val(), 16)
     const lastglyph = parseInt($('#lastglyph').val(), 16)
+    lastchar = 0
 
     $('table.glyph').each(function () {
       const t = $(this)
@@ -628,10 +629,22 @@ $(document).ready(function () {
                 ('    ' + parseInt(t.attr('data-ow'))).slice(-4) + ', ' +
                 ('    ' + parseInt(t.attr('data-oh'))).slice(-4) + ' }   ' +
                 "// '" + t.attr('data-char') + "'" + (t.attr('data-dis') == 1 ? ' disabled' : ''))
-
+      lastchar = t.attr('data-char').charCodeAt(0)
       offset = bitsArray.length
       isFirstCharacter = false
     })
+
+    for(lastchar++; lastchar <= lastglyph ; lastchar++) {
+      glyphs.push(
+        ' ' + (isFirstCharacter ? ' ' : ',') + '{ ' +
+                ('     ' + offset).slice(-5) + ', ' +
+                ('   ' + 0).slice(-3) + ', ' +
+                ('   ' + 0).slice(-3) + ', ' +
+                ('   ' + 0).slice(-3) + ', ' +
+                ('    ' + 0).slice(-4) + ', ' +
+                ('    ' + 0).slice(-4) + ' }   ' +
+                "// '" + String.fromCharCode(lastchar) + "'" )
+    }
 
     // Bitmaps
     let bitmapsOutput = 'const uint8_t ' + name + 'Bitmaps[] PROGMEM = {\n'

--- a/index.html
+++ b/index.html
@@ -586,6 +586,21 @@ $(document).ready(function () {
     const firstglyph = parseInt($('#firstglyph').val(), 16)
     const lastglyph = parseInt($('#lastglyph').val(), 16)
     lastchar = 0
+    
+    let firstglyphtoadd = firstglyph
+    let firstglyphintable = $('table.glyph').first().attr('data-char').charCodeAt(0)
+    for(;firstglyphtoadd < firstglyphintable ; firstglyphtoadd++) {
+      glyphs.push(
+        ' ' + (isFirstCharacter ? ' ' : ',') + '{ ' +
+                ('     ' + offset).slice(-5) + ', ' +
+                ('   ' + 0).slice(-3) + ', ' +
+                ('   ' + 0).slice(-3) + ', ' +
+                ('   ' + 0).slice(-3) + ', ' +
+                ('    ' + 0).slice(-4) + ', ' +
+                ('    ' + 0).slice(-4) + ' }   ' +
+                "// '" + String.fromCharCode(firstglyphtoadd) + "'" )
+        isFirstCharacter = false
+    }
 
     $('table.glyph').each(function () {
       const t = $(this)


### PR DESCRIPTION
This is usable for example when you want to add new characters to a font only containing standard ascii characters.

I used this for a font exporting from 0x20 to 0x7E, when I wanted to add the ° symbol. First I imported the existing font, then I exported with "Last glyph to export" == "0xFF". Then I took the result and imported again, so I could edit the newly added symbols.