### PR TITLE
GFXglyph output formating to include hex representation of character

### DIFF
--- a/index.html
+++ b/index.html
@@ -1102,7 +1102,7 @@ $(document).ready(function () {
                   ('   ' + parseInt(t.attr('data-adv'))).slice(-3) + ', ' +
                   ('    ' + parseInt(t.attr('data-ow'))).slice(-4) + ', ' +
                   ('    ' + parseInt(t.attr('data-oh'))).slice(-4) + ' }' + (isLastCharacter ? ',' : ' ') + '   ' +
-                  "// 0x" + char.charCodeAt(0).toString(16).toUpperCase() + " '" + char + "'")
+                  "// 0x" + char.charCodeAt(0).toString(16).toUpperCase() + (char >= ' ' ? ' "' + char + '"' : ' non printable'))
       } else {
         glyphs.push(
           '  { ' +
@@ -1112,7 +1112,7 @@ $(document).ready(function () {
                   '  0, ' +
                   '   0, ' +
                   '   0 }' + (isLastCharacter ? ',' : ' ') + '   ' +
-                  "// 0x" + char.charCodeAt(0).toString(16).toUpperCase() + " '" + char + "' disabled")
+                  "// 0x" + char.charCodeAt(0).toString(16).toUpperCase() + (char >= ' ' ? ' "' + char + '"' : ' non printable') + ', disabled')
       }
       
       offset = bitsArray.length

--- a/index.html
+++ b/index.html
@@ -1152,8 +1152,8 @@ $(document).ready(function () {
 
     // Create a new last_part with the updated first & last glyph values in it
     let parts = window['last_part'].split(',')    
-    parts[2] = '0x' + firstglyph.toString(16)
-    parts[3] = '0x' + lastglyph.toString(16)
+    parts[2] = '0x' + firstglyph.toString(16).toUpperCase()
+    parts[3] = '0x' + lastglyph.toString(16).toUpperCase()
     const updated_last_part = parts.join(", ",parts)
 
     data = bitmapsOutput + glyphsOutput + updated_last_part

--- a/index.html
+++ b/index.html
@@ -1102,7 +1102,7 @@ $(document).ready(function () {
                   ('   ' + h).slice(-3) + ', ' +
                   ('   ' + parseInt(t.attr('data-adv'))).slice(-3) + ', ' +
                   ('    ' + parseInt(t.attr('data-ow'))).slice(-4) + ', ' +
-                  ('    ' + parseInt(t.attr('data-oh'))).slice(-4) + ' }' + (isFirstCharacter ? ' ' : ',') + '   ' +
+                  ('    ' + parseInt(t.attr('data-oh'))).slice(-4) + ' }' + (isLastCharacter ? ',' : ' ') + '   ' +
                   "// 0x" + char.charCodeAt(0).toString(16).toUpperCase() + " '" + char + "'")
       } else {
         glyphs.push(
@@ -1112,7 +1112,7 @@ $(document).ready(function () {
                   '  0, ' +
                   '  0, ' +
                   '   0, ' +
-                  '   0 }' + (isFirstCharacter ? ' ' : ',') + '   ' +
+                  '   0 }' + (isLastCharacter ? ',' : ' ') + '   ' +
                   "// 0x" + char.charCodeAt(0).toString(16).toUpperCase() + " '" + char + "' disabled")
       }
       

--- a/index.html
+++ b/index.html
@@ -1051,7 +1051,6 @@ $(document).ready(function () {
     const glyphs = []
     const bitsArray = []
     let offset = 0
-    let isFirstCharacter = true
     const firstglyph = parseInt($('#firstglyph').val(), 16)
     const lastglyph = parseInt($('#lastglyph').val(), 16)
 
@@ -1117,7 +1116,6 @@ $(document).ready(function () {
       }
       
       offset = bitsArray.length
-      isFirstCharacter = false
     })
 
     // Bitmaps

--- a/index.html
+++ b/index.html
@@ -1103,7 +1103,7 @@ $(document).ready(function () {
                   ('   ' + parseInt(t.attr('data-adv'))).slice(-3) + ', ' +
                   ('    ' + parseInt(t.attr('data-ow'))).slice(-4) + ', ' +
                   ('    ' + parseInt(t.attr('data-oh'))).slice(-4) + ' }' + (isFirstCharacter ? ' ' : ',') + '   ' +
-                  "// 0x" + char.toString(16) + " '" + char + "'")
+                  "// 0x" + char.charCodeAt(0).toString(16).toUpperCase() + " '" + char + "'")
       } else {
         glyphs.push(
           '  { ' +
@@ -1113,7 +1113,7 @@ $(document).ready(function () {
                   '  0, ' +
                   '   0, ' +
                   '   0 }' + (isFirstCharacter ? ' ' : ',') + '   ' +
-                  "// 0x" + char.toString(16) + " '" + char + "' disabled")
+                  "// 0x" + char.charCodeAt(0).toString(16).toUpperCase() + " '" + char + "' disabled")
       }
       
       offset = bitsArray.length

--- a/index.html
+++ b/index.html
@@ -1094,25 +1094,26 @@ $(document).ready(function () {
       
       if(t.attr('data-dis') == 0)
       {
+
         glyphs.push(
-          ' ' + (isFirstCharacter ? ' ' : ',') + '{ ' +
+          '  { ' +
                   ('     ' + offset).slice(-5) + ', ' +
                   ('   ' + w).slice(-3) + ', ' +
                   ('   ' + h).slice(-3) + ', ' +
                   ('   ' + parseInt(t.attr('data-adv'))).slice(-3) + ', ' +
                   ('    ' + parseInt(t.attr('data-ow'))).slice(-4) + ', ' +
-                  ('    ' + parseInt(t.attr('data-oh'))).slice(-4) + ' }   ' +
-                  "// '" + char + "'")
+                  ('    ' + parseInt(t.attr('data-oh'))).slice(-4) + ' }' + (isFirstCharacter ? ' ' : ',') + '   ' +
+                  "// 0x" + char.toString(16) + " '" + char + "'")
       } else {
         glyphs.push(
-          ' ' + (isFirstCharacter ? ' ' : ',') + '{ ' +
+          '  { ' +
                   '    0, ' +
                   '  0, ' +
                   '  0, ' +
                   '  0, ' +
                   '   0, ' +
-                  '   0 }   ' +
-                  "// '" + char + "' disabled")
+                  '   0 }' + (isFirstCharacter ? ' ' : ',') + '   ' +
+                  "// 0x" + char.toString(16) + " '" + char + "' disabled")
       }
       
       offset = bitsArray.length

--- a/index.html
+++ b/index.html
@@ -1102,7 +1102,7 @@ $(document).ready(function () {
                   ('   ' + parseInt(t.attr('data-adv'))).slice(-3) + ', ' +
                   ('    ' + parseInt(t.attr('data-ow'))).slice(-4) + ', ' +
                   ('    ' + parseInt(t.attr('data-oh'))).slice(-4) + ' }' + (isLastCharacter ? ',' : ' ') + '   ' +
-                  "// 0x" + char.charCodeAt(0).toString(16).toUpperCase() + (char >= ' ' ? ' "' + char + '"' : ' non printable'))
+                  "// 0x" + char.charCodeAt(0).toString(16).toUpperCase() + (char >= ' ' ? " '" + char + "'" : ' non printable'))
       } else {
         glyphs.push(
           '  { ' +
@@ -1112,7 +1112,7 @@ $(document).ready(function () {
                   '  0, ' +
                   '   0, ' +
                   '   0 }' + (isLastCharacter ? ',' : ' ') + '   ' +
-                  "// 0x" + char.charCodeAt(0).toString(16).toUpperCase() + (char >= ' ' ? ' "' + char + '"' : ' non printable') + ', disabled')
+                  "// 0x" + char.charCodeAt(0).toString(16).toUpperCase() + (char >= ' ' ? " '" + char + "'" : ' non printable') + ', disabled')
       }
       
       offset = bitsArray.length


### PR DESCRIPTION
```cpp
  {  3579,  17,  19,  19,    1,  -18 },   // 0x6F 'o'
```
instead of 
```cpp
 ,{  3579,  17,  19,  19,    1,  -18 }   // 'o'
```
