### PR TITLE
Improve glyph editor box visual separation

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,8 +144,8 @@
       justify-content: center;
     }
     .glyph-grid > div {
-      padding-left: 1rem;
-      padding-right: 1rem;
+      margin: 1.5rem;
+      box-shadow: 3px 3px 8px rgba(0,0,0,0.15);
     }
    </style>
 </head>


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Fixes #30 

Adds top & bottom margin and a subtle box shadow to enhance the visual separation of the glyph editor boxes.

**APPEARANCE BEFORE CHANGES**
<img width="1721" alt="Screen Shot 2021-12-07 at 10 31 48 AM" src="https://user-images.githubusercontent.com/84106309/145047978-ffcb7956-49c5-4a2b-b016-1473cb76e132.png">

**APPEARANCE AFTER CHANGES**
<img width="1724" alt="Screen Shot 2021-12-07 at 10 33 25 AM" src="https://user-images.githubusercontent.com/84106309/145048371-e69dae55-d137-459b-b10f-0db25ebd41cc.png">

